### PR TITLE
feat(repository-layer): Add repository layer to add abstraction

### DIFF
--- a/ApexCare/ApexCare/Repositories/IRepository.cs
+++ b/ApexCare/ApexCare/Repositories/IRepository.cs
@@ -1,0 +1,16 @@
+using System.Linq.Expressions;
+
+namespace ApexCare.Repositories
+{
+    public interface IRepository<T> where T : class
+    {
+        Task<T> GetAsync(Expression<Func<T, bool>>? filter = null);
+        Task<int> UpdateAsync(T entity);
+        Task<int> UpdateAsync(T[] entity);
+        Task<bool> CreateAsync(T entity);
+        Task<bool> CreateAsync(T[] entities);
+        Task<bool> DeleteAsync(T entity);
+        Task<bool> DeleteAsync(T[] entity);
+        Task SaveAsync();
+    }    
+}

--- a/ApexCare/ApexCare/Repositories/Repository.cs
+++ b/ApexCare/ApexCare/Repositories/Repository.cs
@@ -1,0 +1,56 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+
+namespace ApexCare.Repositories{
+public class Repository<T>: IRepository<T> where T : class
+    {
+        internal DbContext context;
+        internal DbSet<T> dbSet;
+
+        public Repository(DbContext context)
+        {
+            this.context = context;
+            this.dbSet = context.Set<T>();
+        }
+
+        public Task<bool> CreateAsync(T entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> CreateAsync(T[] entities)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> DeleteAsync(T entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> DeleteAsync(T[] entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<T> GetAsync(Expression<Func<T, bool>>? filter = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SaveAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<int> UpdateAsync(T entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<int> UpdateAsync(T[] entity)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION

Added repository layer to add layer of abstraction to data access layer making it easy to change database providers and different ORMs in the future without having to refactor too much. This will allow us to only change the implementation in the repository.

refs: #24